### PR TITLE
Avoid auto-install on npm7

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
     "webpack": "^5.31.0",
     "webpack-cli": "^4.6.0"
   },
-  "peerDependencies": {
-    "phaser-ce": "2.10.3"
+  "peerDependenciesMeta": {
+    "phaser-ce": {
+      "optional": true
+    }
   },
   "dependencies": {
     "eventemitter3": "^4.0.7"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,15 @@
     "webpack": "^5.31.0",
     "webpack-cli": "^4.6.0"
   },
+  "peerDependencies": {
+    "phaser-ce": "2.10.3",
+    "phaser": "^3.55.2"
+  },
   "peerDependenciesMeta": {
     "phaser-ce": {
+      "optional": true
+    },
+    "phaser": {
       "optional": true
     }
   },


### PR DESCRIPTION
npm 7 automatically installs peerDependencies, resulting in automatically installing ""phaser-ce 2.10.3", which is especially undesireable when developing with Phaser 3.